### PR TITLE
Deprecate parameter evaluation_strategy in TrainerSettings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -164,6 +164,8 @@ disable=
     R0901,
     # logging-fstring-interpolation
     W1203,
+    # Using open without explicitly specifying an encoding (unspecified-encoding)
+    W1514,
 ignore=
     data
 ignore-patterns=

--- a/tests/fixtures/configs/train/classification/base.json
+++ b/tests/fixtures/configs/train/classification/base.json
@@ -93,7 +93,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 1,

--- a/tests/fixtures/configs/train/ddpo/base.json
+++ b/tests/fixtures/configs/train/ddpo/base.json
@@ -133,7 +133,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 1,

--- a/tests/fixtures/configs/train/dpo/base.json
+++ b/tests/fixtures/configs/train/dpo/base.json
@@ -112,7 +112,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 2,
         "per_device_eval_batch_size": 2,
         "gradient_accumulation_steps": 2,

--- a/tests/fixtures/configs/train/dpo/simpo.json
+++ b/tests/fixtures/configs/train/dpo/simpo.json
@@ -104,7 +104,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 2,
         "per_device_eval_batch_size": 2,
         "gradient_accumulation_steps": 2,

--- a/tests/fixtures/configs/train/kto/base.json
+++ b/tests/fixtures/configs/train/kto/base.json
@@ -90,7 +90,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 4,
         "per_device_eval_batch_size": 4,
         "gradient_accumulation_steps": 1,

--- a/tests/fixtures/configs/train/multimodal/llama_c_abs_clip_pickle.json
+++ b/tests/fixtures/configs/train/multimodal/llama_c_abs_clip_pickle.json
@@ -109,7 +109,7 @@
       "pad_token": "<pad>"
   },
     "trainer_settings": {
-      "evaluation_strategy": "epoch",
+      "eval_strategy": "epoch",
       "save_strategy": "epoch",
       "per_device_train_batch_size": 1,
       "per_device_eval_batch_size": 1,

--- a/tests/fixtures/configs/train/multimodal/llama_llava_base_clip.json
+++ b/tests/fixtures/configs/train/multimodal/llama_llava_base_clip.json
@@ -109,7 +109,7 @@
       "pad_token": "<pad>"
   },
     "trainer_settings": {
-      "evaluation_strategy": "epoch",
+      "eval_strategy": "epoch",
       "save_strategy": "epoch",
       "per_device_train_batch_size": 1,
       "per_device_eval_batch_size": 1,

--- a/tests/fixtures/configs/train/multimodal/llama_llava_clip_pickle.json
+++ b/tests/fixtures/configs/train/multimodal/llama_llava_clip_pickle.json
@@ -109,7 +109,7 @@
       "pad_token": "<pad>"
   },
     "trainer_settings": {
-      "evaluation_strategy": "epoch",
+      "eval_strategy": "epoch",
       "save_strategy": "epoch",
       "per_device_train_batch_size": 1,
       "per_device_eval_batch_size": 1,

--- a/tests/fixtures/configs/train/rag/end2end.json
+++ b/tests/fixtures/configs/train/rag/end2end.json
@@ -125,7 +125,7 @@
     "pad_token": "<pad>"
 },
   "trainer_settings": {
-    "evaluation_strategy": "epoch",
+    "eval_strategy": "epoch",
     "save_strategy": "epoch",
     "per_device_train_batch_size": 1,
     "per_device_eval_batch_size": 1,

--- a/tests/fixtures/configs/train/rm/base.json
+++ b/tests/fixtures/configs/train/rm/base.json
@@ -95,7 +95,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 1,

--- a/tests/fixtures/configs/train/sft/base.json
+++ b/tests/fixtures/configs/train/sft/base.json
@@ -106,7 +106,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 1,

--- a/tests/fixtures/configs/train/sft/prompt_tuning.json
+++ b/tests/fixtures/configs/train/sft/prompt_tuning.json
@@ -101,7 +101,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 1,

--- a/tests/fixtures/configs/train/sft/resume_from_checkpoint.json
+++ b/tests/fixtures/configs/train/sft/resume_from_checkpoint.json
@@ -85,7 +85,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 1,

--- a/tests/fixtures/configs/train/sft/sft_retrieval_utility.json
+++ b/tests/fixtures/configs/train/sft/sft_retrieval_utility.json
@@ -114,7 +114,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 1,

--- a/tests/fixtures/configs/train/sft/sft_with_rm_metric.json
+++ b/tests/fixtures/configs/train/sft/sft_with_rm_metric.json
@@ -128,7 +128,7 @@
         "pad_token": "<pad>"
     },
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 1,

--- a/tests/fixtures/models/llama2_tiny_fine_tuned_with_adapters/experiment_settings_config.json
+++ b/tests/fixtures/models/llama2_tiny_fine_tuned_with_adapters/experiment_settings_config.json
@@ -1,6 +1,6 @@
 {
     "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 1,

--- a/tests/unit/test_trainer_settings.py
+++ b/tests/unit/test_trainer_settings.py
@@ -6,6 +6,7 @@ from tests.constants import FIXTURES_PATH
 from turbo_alignment.settings import pipelines as pipeline_settings
 
 
+# TODO: remove in future
 @pytest.mark.parametrize(
     'config_path, settings_cls',
     [

--- a/tests/unit/test_trainer_settings.py
+++ b/tests/unit/test_trainer_settings.py
@@ -1,0 +1,23 @@
+import json
+
+import pytest
+
+from tests.constants import FIXTURES_PATH
+from turbo_alignment.settings import pipelines as pipeline_settings
+
+
+@pytest.mark.parametrize(
+    'config_path, settings_cls',
+    [
+        (FIXTURES_PATH / 'configs/train/sft/base.json', pipeline_settings.SftTrainExperimentSettings),
+        (FIXTURES_PATH / 'configs/train/dpo/base.json', pipeline_settings.DPOTrainExperimentSettings),
+        (FIXTURES_PATH / 'configs/train/kto/base.json', pipeline_settings.KTOTrainExperimentSettings),
+    ],
+)
+def test_evaluation_strategy_warning(config_path, settings_cls):
+    match_str = (
+        "'evaluation_strategy' is deprecated and will be removed in a future version. Use 'eval_strategy' instead."
+    )
+    with pytest.warns(FutureWarning, match=match_str):
+        with open(config_path) as f:
+            settings_cls.model_validate(json.load(f))

--- a/tests/unit/test_trainer_settings.py
+++ b/tests/unit/test_trainer_settings.py
@@ -20,7 +20,9 @@ def test_evaluation_strategy_deprecation(config_path, settings_cls):
     )
     with pytest.warns(FutureWarning, match=match_str):
         with open(config_path) as f:
-            settings = settings_cls.model_validate(json.load(f))
+            json_data = json.load(f)
+        json_data["trainer_settings"]["evaluation_strategy"] = json_data["trainer_settings"].pop("eval_strategy")
+        settings = settings_cls.model_validate(json_data)
 
     trainer_settings = settings.trainer_settings
     assert not hasattr(trainer_settings, 'evaluation_strategy')

--- a/tests/unit/test_trainer_settings.py
+++ b/tests/unit/test_trainer_settings.py
@@ -21,7 +21,8 @@ def test_evaluation_strategy_deprecation(config_path, settings_cls):
     with pytest.warns(FutureWarning, match=match_str):
         with open(config_path) as f:
             settings = settings_cls.model_validate(json.load(f))
-    
-    assert not hasattr(settings, 'evaluation_strategy')
-    assert hasattr(settings, 'eval_strategy')
-    assert settings.eval_strategy == 'steps'
+
+    trainer_settings = settings.trainer_settings
+    assert not hasattr(trainer_settings, 'evaluation_strategy')
+    assert hasattr(trainer_settings, 'eval_strategy')
+    assert trainer_settings.eval_strategy == 'steps'

--- a/tests/unit/test_trainer_settings.py
+++ b/tests/unit/test_trainer_settings.py
@@ -14,10 +14,14 @@ from turbo_alignment.settings import pipelines as pipeline_settings
         (FIXTURES_PATH / 'configs/train/kto/base.json', pipeline_settings.KTOTrainExperimentSettings),
     ],
 )
-def test_evaluation_strategy_warning(config_path, settings_cls):
+def test_evaluation_strategy_deprecation(config_path, settings_cls):
     match_str = (
         "'evaluation_strategy' is deprecated and will be removed in a future version. Use 'eval_strategy' instead."
     )
     with pytest.warns(FutureWarning, match=match_str):
         with open(config_path) as f:
-            settings_cls.model_validate(json.load(f))
+            settings = settings_cls.model_validate(json.load(f))
+    
+    assert not hasattr(settings, 'evaluation_strategy')
+    assert hasattr(settings, 'eval_strategy')
+    assert settings.eval_strategy == 'steps'

--- a/turbo_alignment/settings/tf/trainer.py
+++ b/turbo_alignment/settings/tf/trainer.py
@@ -1,11 +1,14 @@
+import warnings
 from pathlib import Path
 from typing import Any
+
+from pydantic import Field, field_validator
 
 from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 
 
 class TrainerSettings(ExtraFieldsNotAllowedBaseModel):
-    evaluation_strategy: str = 'steps'
+    eval_strategy: str = 'steps'
     save_strategy: str = 'steps'
     per_device_train_batch_size: int = 4
     per_device_eval_batch_size: int = 4
@@ -47,3 +50,15 @@ class TrainerSettings(ExtraFieldsNotAllowedBaseModel):
     gradient_checkpointing_kwargs: dict[str, Any] = {}
     neftune_noise_alpha: float | None = None
     report_to: list[str] = []
+
+    evaluation_strategy: str | None = Field(default=None, deprecated=True)
+
+    @field_validator('evaluation_strategy')
+    def sync_eval_strategy(cls, v, values):
+        warning_str = (
+            "'evaluation_strategy' is deprecated and will be removed in a future version. Use 'eval_strategy' instead."
+        )
+        if v is not None:
+            warnings.warn(warning_str, FutureWarning)
+            return v
+        return values['eval_strategy']

--- a/turbo_alignment/settings/tf/trainer.py
+++ b/turbo_alignment/settings/tf/trainer.py
@@ -2,7 +2,7 @@ import warnings
 from pathlib import Path
 from typing import Any
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import model_validator
 
 from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 
@@ -57,8 +57,9 @@ class TrainerSettings(ExtraFieldsNotAllowedBaseModel):
     def handle_deprecated_evaluation_strategy(cls, values):
         if 'evaluation_strategy' in values:
             warnings.warn(
-                "'evaluation_strategy' is deprecated and will be removed in a future version. Use 'eval_strategy' instead.",
-                FutureWarning
+                "'evaluation_strategy' is deprecated and will be removed in a future version. "
+                "Use 'eval_strategy' instead.",
+                FutureWarning,
             )
             values['eval_strategy'] = values.pop('evaluation_strategy')
         return values

--- a/tutorials/dpo/dpo.json
+++ b/tutorials/dpo/dpo.json
@@ -98,7 +98,7 @@
             "eos_token": "<|end_of_text|>"
         },
       "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 2,

--- a/tutorials/kto/kto.json
+++ b/tutorials/kto/kto.json
@@ -96,7 +96,7 @@
         "eos_token": "<|end_of_text|>"
         },
       "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 2,

--- a/tutorials/multimodal/multimodal.json
+++ b/tutorials/multimodal/multimodal.json
@@ -108,7 +108,7 @@
       "eos_token": "</s>"
       },
     "trainer_settings": {
-      "evaluation_strategy": "steps",
+      "eval_strategy": "steps",
       "save_strategy": "steps",
       "per_device_train_batch_size": 1,
       "per_device_eval_batch_size": 1,

--- a/tutorials/rm/rm.json
+++ b/tutorials/rm/rm.json
@@ -85,7 +85,7 @@
         "eos_token": "<|end_of_text|>"
         },
       "trainer_settings": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "per_device_train_batch_size": 1,
         "per_device_eval_batch_size": 1,
         "gradient_accumulation_steps": 16,

--- a/tutorials/sft/sft.json
+++ b/tutorials/sft/sft.json
@@ -89,7 +89,7 @@
       "eos_token": "<|end_of_text|>"
       },
     "trainer_settings": {
-      "evaluation_strategy": "steps",
+      "eval_strategy": "steps",
       "save_total_limit": 5,
       "load_best_model_at_end": false,
       "per_device_train_batch_size": 1,


### PR DESCRIPTION
This parameter is already [deprecated](https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py#L1575) in transformers. I am not sure, how you are managing deprecation of features, therefore I used `will be removed in a future version` in the warning.

Also added change to setup.cfg, otherwise pylint fails, because `encoding` is not specified in `with open(config_path) as f:`. If you mind, I can specify `encoding="ascii"`.

