### PR TITLE
Add minimal vllm engine setting

### DIFF
--- a/tests/fixtures/configs/inference/sft/vllm_base.json
+++ b/tests/fixtures/configs/inference/sft/vllm_base.json
@@ -1,6 +1,11 @@
 {
   "inference_settings": [
     {
+      "vllm_engine_settings": {
+        "tensor_parallel_size": 2,
+        "max_lora_rank": 128,
+        "max_logprobs": 400000
+      },
       "model_settings": {
         "model_path": "tests/fixtures/models/llama2_tiny",
         "model_type": "causal",
@@ -15,13 +20,13 @@
         {
           "transformers_settings": {
             "num_beams": 3,
-            "max_new_tokens": 8
+            "max_new_tokens": 8,
+            "logprobs": 100
           },
           "custom_settings": {}
         }
       ],
-      "use_vllm": true,
-      "tensor_parallel_size": 2
+      "use_vllm": true
     }
   ],
   "dataset_settings": {

--- a/tests/fixtures/configs/inference/sft/vllm_base.json
+++ b/tests/fixtures/configs/inference/sft/vllm_base.json
@@ -1,11 +1,6 @@
 {
   "inference_settings": [
     {
-      "vllm_engine_settings": {
-        "tensor_parallel_size": 2,
-        "max_lora_rank": 128,
-        "max_logprobs": 400000
-      },
       "model_settings": {
         "model_path": "tests/fixtures/models/llama2_tiny",
         "model_type": "causal",
@@ -26,7 +21,12 @@
           "custom_settings": {}
         }
       ],
-      "use_vllm": true
+      "use_vllm": true,
+      "vllm_engine_settings": {
+        "tensor_parallel_size": 2,
+        "max_lora_rank": 128,
+        "max_logprobs": 400000
+      }
     }
   ],
   "dataset_settings": {

--- a/tests/fixtures/configs/inference/sft/vllm_base.json
+++ b/tests/fixtures/configs/inference/sft/vllm_base.json
@@ -11,8 +11,20 @@
         "use_fast": false,
         "tokenizer_path": "tests/fixtures/models/llama2_tiny_fine_tuned_with_adapters/tokenizer_with_special_tokens"
       },
+      "use_vllm": true,
+      "vllm_engine_settings": {
+        "max_lora_rank": 32,
+        "tensor_parallel_size": 1
+      },
       "generation_settings": [
         {
+          "vllm_settings": {
+            "n": 1,
+            "repetition_penalty": 1.02,
+            "max_tokens": 16,
+            "top_k": -1,
+            "stop_strings": "<|im_end|>"
+          },
           "transformers_settings": {
             "num_beams": 3,
             "max_new_tokens": 8,
@@ -20,13 +32,7 @@
           },
           "custom_settings": {}
         }
-      ],
-      "use_vllm": true,
-      "vllm_engine_settings": {
-        "tensor_parallel_size": 2,
-        "max_lora_rank": 128,
-        "max_logprobs": 400000
-      }
+      ]
     }
   ],
   "dataset_settings": {

--- a/turbo_alignment/cherry_picks/multimodal.py
+++ b/turbo_alignment/cherry_picks/multimodal.py
@@ -1,10 +1,10 @@
 from typing import Iterable
 
 import torch
+import wandb
 from PIL import Image
 from transformers import PreTrainedTokenizerBase
 
-import wandb
 from turbo_alignment.cherry_picks.base import CherryPickCallbackBase
 from turbo_alignment.dataset.multimodal import InferenceMultimodalDataset
 from turbo_alignment.generators.multimodal import MultimodalGenerator

--- a/turbo_alignment/common/logging/weights_and_biases.py
+++ b/turbo_alignment/common/logging/weights_and_biases.py
@@ -1,9 +1,9 @@
 from typing import Any
 
+import wandb
 from wandb.sdk.lib.disabled import RunDisabled
 from wandb.sdk.wandb_run import Run
 
-import wandb
 from turbo_alignment.settings.logging.weights_and_biases import WandbSettings
 
 

--- a/turbo_alignment/common/tf/callbacks/logging.py
+++ b/turbo_alignment/common/tf/callbacks/logging.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+import wandb
 from clearml import Task
 from transformers import (
     TrainerCallback,
@@ -13,7 +14,6 @@ from transformers import (
 from wandb.sdk.lib.disabled import RunDisabled
 from wandb.sdk.wandb_run import Run
 
-import wandb
 from turbo_alignment.common.logging import get_project_logger
 
 logger = get_project_logger()

--- a/turbo_alignment/generators/vllm_chat.py
+++ b/turbo_alignment/generators/vllm_chat.py
@@ -51,6 +51,7 @@ class VLLMChatGenerator(BaseGenerator[ChatDatasetRecord, ChatInferenceOutput]):
             skip_special_tokens=custom_generation_settings.skip_special_tokens,
             stop_token_ids=eos_token_id,
             max_tokens=transformers_settings.max_new_tokens,
+            logprobs=transformers_settings.logprobs,
             **beam_search_params,
         )
         self._lora_request = lora_request
@@ -77,6 +78,7 @@ class VLLMChatGenerator(BaseGenerator[ChatDatasetRecord, ChatInferenceOutput]):
                     id=str(a.index),
                     content=a.text,
                     sequence_score=a.cumulative_logprob,
+                    logprobs=a.logprobs if a.logprobs else None,
                 )
                 if self._return_logits:
                     ans_msg.input_token_ids = torch.tensor(request_output.prompt_token_ids).unsqueeze(0)

--- a/turbo_alignment/generators/vllm_chat.py
+++ b/turbo_alignment/generators/vllm_chat.py
@@ -36,7 +36,7 @@ class VLLMChatGenerator(BaseGenerator[ChatDatasetRecord, ChatInferenceOutput]):
 
         beam_search_params: dict[str, Any] = {
             'use_beam_search': transformers_settings.use_beam_search,
-            'best_of': transformers_settings.sampling_params.n
+            'best_of': transformers_settings.sampling_params.n,
         }
         if transformers_settings.use_beam_search:
             beam_search_params['best_of'] = transformers_settings.best_of

--- a/turbo_alignment/pipelines/inference/chat.py
+++ b/turbo_alignment/pipelines/inference/chat.py
@@ -49,8 +49,7 @@ class ChatInferenceStrategy(BaseInferenceStrategy[ChatInferenceExperimentSetting
                     lora_request = LoRARequest('adapter', 1, str(model_inference_settings.model_settings.adapter_path))
 
                 model = vllm.LLM(
-                    model=model_inference_settings.model_settings.model_path.absolute().as_posix(),
-                    **engine_settings
+                    model=model_inference_settings.model_settings.model_path.absolute().as_posix(), **engine_settings
                 )
 
             else:

--- a/turbo_alignment/pipelines/inference/chat.py
+++ b/turbo_alignment/pipelines/inference/chat.py
@@ -35,14 +35,18 @@ class ChatInferenceStrategy(BaseInferenceStrategy[ChatInferenceExperimentSetting
                 lora_request: LoRARequest | None = None
 
                 engine_settings = model_inference_settings.vllm_engine_settings.dict()
-                engine_settings.update({
-                    'model': model_inference_settings.model_settings.model_path.absolute().as_posix(),
-                    'gpu_memory_utilization': 0.95,
-                    'dtype': 'bfloat16',
-                    'enable_lora': isinstance(model_inference_settings.model_settings, PreTrainedAdaptersModelSettings),
-                })
+                engine_settings.update(
+                    {
+                        'model': model_inference_settings.model_settings.model_path.absolute().as_posix(),
+                        'gpu_memory_utilization': 0.95,
+                        'dtype': 'bfloat16',
+                        'enable_lora': isinstance(
+                            model_inference_settings.model_settings, PreTrainedAdaptersModelSettings
+                        ),
+                    }
+                )
 
-                if engine_settings["enable_lora"]:
+                if engine_settings['enable_lora']:
                     lora_request = LoRARequest('adapter', 1, str(model_inference_settings.model_settings.adapter_path))
 
                 model = vllm.LLM(**engine_settings)

--- a/turbo_alignment/pipelines/inference/chat.py
+++ b/turbo_alignment/pipelines/inference/chat.py
@@ -35,16 +35,7 @@ class ChatInferenceStrategy(BaseInferenceStrategy[ChatInferenceExperimentSetting
                 lora_request: LoRARequest | None = None
 
                 engine_settings = model_inference_settings.vllm_engine_settings.dict()
-                engine_settings.update(
-                    {
-                        'gpu_memory_utilization': 0.95,
-                        'dtype': 'bfloat16',
-                        'enable_lora': isinstance(
-                            model_inference_settings.model_settings, PreTrainedAdaptersModelSettings
-                        ),
-                    }
-                )
-
+                engine_settings['enable_lora'] = isinstance(model_inference_settings.model_settings, PreTrainedAdaptersModelSettings)
                 if engine_settings['enable_lora']:
                     lora_request = LoRARequest('adapter', 1, str(model_inference_settings.model_settings.adapter_path))
 

--- a/turbo_alignment/pipelines/inference/chat.py
+++ b/turbo_alignment/pipelines/inference/chat.py
@@ -37,7 +37,6 @@ class ChatInferenceStrategy(BaseInferenceStrategy[ChatInferenceExperimentSetting
                 engine_settings = model_inference_settings.vllm_engine_settings.dict()
                 engine_settings.update(
                     {
-                        'model': model_inference_settings.model_settings.model_path.absolute().as_posix(),
                         'gpu_memory_utilization': 0.95,
                         'dtype': 'bfloat16',
                         'enable_lora': isinstance(
@@ -49,7 +48,10 @@ class ChatInferenceStrategy(BaseInferenceStrategy[ChatInferenceExperimentSetting
                 if engine_settings['enable_lora']:
                     lora_request = LoRARequest('adapter', 1, str(model_inference_settings.model_settings.adapter_path))
 
-                model = vllm.LLM(**engine_settings)
+                model = vllm.LLM(
+                    model=model_inference_settings.model_settings.model_path.absolute().as_posix(),
+                    **engine_settings
+                )
 
             else:
                 model = load_model(model_inference_settings.model_settings, tokenizer)

--- a/turbo_alignment/pipelines/inference/chat.py
+++ b/turbo_alignment/pipelines/inference/chat.py
@@ -35,7 +35,9 @@ class ChatInferenceStrategy(BaseInferenceStrategy[ChatInferenceExperimentSetting
                 lora_request: LoRARequest | None = None
 
                 engine_settings = model_inference_settings.vllm_engine_settings.dict()
-                engine_settings['enable_lora'] = isinstance(model_inference_settings.model_settings, PreTrainedAdaptersModelSettings)
+                engine_settings['enable_lora'] = isinstance(
+                    model_inference_settings.model_settings, PreTrainedAdaptersModelSettings
+                )
                 if engine_settings['enable_lora']:
                     lora_request = LoRARequest('adapter', 1, str(model_inference_settings.model_settings.adapter_path))
 

--- a/turbo_alignment/pipelines/inference/chat.py
+++ b/turbo_alignment/pipelines/inference/chat.py
@@ -57,18 +57,19 @@ class ChatInferenceStrategy(BaseInferenceStrategy[ChatInferenceExperimentSetting
                 generator_kwargs = {
                     'model': model,
                     'tokenizer': tokenizer,
-                    'transformers_settings': generation_settings.transformers_settings,
                     'custom_generation_settings': generation_settings.custom_settings,
                     'batch': model_inference_settings.batch,
                 }
                 generator = (
                     ChatGenerator(
                         **generator_kwargs,
+                        transformers_settings=generation_settings.transformers_settings,
                         accelerator=accelerator,
                     )
                     if not model_inference_settings.use_vllm
                     else VLLMChatGenerator(
                         **generator_kwargs,
+                        generator_settings=generation_settings.vllm_settings,
                         lora_request=lora_request,
                     )
                 )

--- a/turbo_alignment/settings/generators/outputs/chat.py
+++ b/turbo_alignment/settings/generators/outputs/chat.py
@@ -13,7 +13,6 @@ class AnswerMessage(ExtraFieldsNotAllowedBaseModel):
     answer_token_ids: torch.Tensor | None = None
     logits: torch.Tensor | None = None
     logprobs: list | None = None
-    token_ids: list | None = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/turbo_alignment/settings/generators/outputs/chat.py
+++ b/turbo_alignment/settings/generators/outputs/chat.py
@@ -12,6 +12,8 @@ class AnswerMessage(ExtraFieldsNotAllowedBaseModel):
     input_token_ids: torch.Tensor | None = None
     answer_token_ids: torch.Tensor | None = None
     logits: torch.Tensor | None = None
+    logprobs: list | None = None
+    token_ids: list | None = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/turbo_alignment/settings/pipelines/inference/base.py
+++ b/turbo_alignment/settings/pipelines/inference/base.py
@@ -14,6 +14,7 @@ from turbo_alignment.settings.model import (
     PreTrainedModelSettings,
 )
 from turbo_alignment.settings.tf.tokenizer import TokenizerSettings
+from turbo_alignment.settings.tf.vllm import EngineSettings
 
 INFERENCE_DATASETS_SETTINGS = Annotated[
     ChatMultiDatasetSettings | ClassificationMultiDatasetSettings | MultimodalMultiDatasetSettings,
@@ -27,6 +28,7 @@ class SingleModelInferenceSettings(ExtraFieldsNotAllowedBaseModel):
     use_vllm: bool = False
     batch: int = 1
     micro_batch: int = 1
+    vllm_engine_settings: EngineSettings = Field(default_factory=EngineSettings)
 
 
 class InferenceExperimentSettings(ExtraFieldsNotAllowedBaseModel):

--- a/turbo_alignment/settings/pipelines/inference/base.py
+++ b/turbo_alignment/settings/pipelines/inference/base.py
@@ -14,7 +14,6 @@ from turbo_alignment.settings.model import (
     PreTrainedModelSettings,
 )
 from turbo_alignment.settings.tf.tokenizer import TokenizerSettings
-from turbo_alignment.settings.tf.vllm import EngineSettings
 
 INFERENCE_DATASETS_SETTINGS = Annotated[
     ChatMultiDatasetSettings | ClassificationMultiDatasetSettings | MultimodalMultiDatasetSettings,
@@ -28,7 +27,6 @@ class SingleModelInferenceSettings(ExtraFieldsNotAllowedBaseModel):
     use_vllm: bool = False
     batch: int = 1
     micro_batch: int = 1
-    vllm_engine_settings: EngineSettings = Field(default_factory=EngineSettings)
 
 
 class InferenceExperimentSettings(ExtraFieldsNotAllowedBaseModel):

--- a/turbo_alignment/settings/pipelines/inference/chat.py
+++ b/turbo_alignment/settings/pipelines/inference/chat.py
@@ -16,8 +16,9 @@ from turbo_alignment.settings.tf.vllm import EngineSettings
 
 
 class ChatGenerationSettings(ExtraFieldsNotAllowedBaseModel):
-    transformers_settings: GeneratorTransformersSettings | VLLMGeneratorSettings
-    custom_settings: CustomChatGenerationSettings
+    transformers_settings: GeneratorTransformersSettings = Field(default_factory=GeneratorTransformersSettings)
+    vllm_settings: VLLMGeneratorSettings = Field(default_factory=VLLMGeneratorSettings)
+    custom_settings: CustomChatGenerationSettings = Field(default_factory=CustomChatGenerationSettings)
 
 
 class ChatSingleModelInferenceSettings(SingleModelInferenceSettings):

--- a/turbo_alignment/settings/pipelines/inference/chat.py
+++ b/turbo_alignment/settings/pipelines/inference/chat.py
@@ -1,12 +1,17 @@
 from typing import Sequence
+
 from pydantic import Field
+
 from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 from turbo_alignment.settings.generators.chat import CustomChatGenerationSettings
 from turbo_alignment.settings.pipelines.inference.base import (
     InferenceExperimentSettings,
     SingleModelInferenceSettings,
 )
-from turbo_alignment.settings.tf.generation import GeneratorTransformersSettings, VLLMGeneratorSettings
+from turbo_alignment.settings.tf.generation import (
+    GeneratorTransformersSettings,
+    VLLMGeneratorSettings,
+)
 from turbo_alignment.settings.tf.vllm import EngineSettings
 
 

--- a/turbo_alignment/settings/pipelines/inference/chat.py
+++ b/turbo_alignment/settings/pipelines/inference/chat.py
@@ -17,7 +17,6 @@ class ChatGenerationSettings(ExtraFieldsNotAllowedBaseModel):
 class ChatSingleModelInferenceSettings(SingleModelInferenceSettings):
     generation_settings: list[ChatGenerationSettings]
     use_vllm: bool = False
-    tensor_parallel_size: int = 1
 
 
 class ChatInferenceExperimentSettings(InferenceExperimentSettings):

--- a/turbo_alignment/settings/pipelines/inference/chat.py
+++ b/turbo_alignment/settings/pipelines/inference/chat.py
@@ -1,22 +1,24 @@
 from typing import Sequence
-
+from pydantic import Field
 from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 from turbo_alignment.settings.generators.chat import CustomChatGenerationSettings
 from turbo_alignment.settings.pipelines.inference.base import (
     InferenceExperimentSettings,
     SingleModelInferenceSettings,
 )
-from turbo_alignment.settings.tf.generation import GeneratorTransformersSettings
+from turbo_alignment.settings.tf.generation import GeneratorTransformersSettings, VLLMGeneratorSettings
+from turbo_alignment.settings.tf.vllm import EngineSettings
 
 
 class ChatGenerationSettings(ExtraFieldsNotAllowedBaseModel):
-    transformers_settings: GeneratorTransformersSettings
+    transformers_settings: GeneratorTransformersSettings | VLLMGeneratorSettings
     custom_settings: CustomChatGenerationSettings
 
 
 class ChatSingleModelInferenceSettings(SingleModelInferenceSettings):
     generation_settings: list[ChatGenerationSettings]
     use_vllm: bool = False
+    vllm_engine_settings: EngineSettings = Field(default_factory=EngineSettings)
 
 
 class ChatInferenceExperimentSettings(InferenceExperimentSettings):

--- a/turbo_alignment/settings/tf/generation.py
+++ b/turbo_alignment/settings/tf/generation.py
@@ -11,3 +11,4 @@ class GeneratorTransformersSettings(ExtraFieldsNotAllowedBaseModel):
     top_k: int = 50
     temperature: float = 1.0
     stop_strings: str | list[str] = '</s>'
+    logprobs: int | None = None

--- a/turbo_alignment/settings/tf/generation.py
+++ b/turbo_alignment/settings/tf/generation.py
@@ -1,32 +1,25 @@
-from pydantic import Field
-
 from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 
 
-class GeneratorTransformersSettings(ExtraFieldsNotAllowedBaseModel):
+class BaseGeneratorSettings(ExtraFieldsNotAllowedBaseModel):
+    repetition_penalty: float = 1.0
+    temperature: float = 1.0
+    top_p: float = 1.0
+    top_k: int = 50
+    stop_strings: str | list[str] = '</s>'
+
+
+class GeneratorTransformersSettings(BaseGeneratorSettings):
     num_beams: int = 1
     max_new_tokens: int = 15
-    repetition_penalty: float = 1.0
     num_return_sequences: int = 1
     do_sample: bool = True
-    top_p: float = 1.0
-    top_k: int = 50
-    temperature: float = 1.0
-    stop_strings: str | list[str] = '</s>'
 
 
-class VLLMSampleingSettings(ExtraFieldsNotAllowedBaseModel):
+class VLLMGeneratorSettings(BaseGeneratorSettings):
     n: int = 1
-    repetition_penalty: float = 1.0
-    temperature: float = 1.0
-    top_p: float = 1.0
-    top_k: int = 50
     max_tokens: int = 15
     logprobs: int | None = None
-
-
-class VLLMGeneratorSettings(ExtraFieldsNotAllowedBaseModel):
-    sampling_params: VLLMSampleingSettings = Field(default_factory=VLLMSampleingSettings)
     best_of: int = 1
     use_beam_search: bool = False
-    stop_strings: str | list[str] = '</s>'
+    filter_token_ids: list[int] | None = None

--- a/turbo_alignment/settings/tf/generation.py
+++ b/turbo_alignment/settings/tf/generation.py
@@ -1,5 +1,5 @@
 from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
-
+from pydantic import Field
 
 class GeneratorTransformersSettings(ExtraFieldsNotAllowedBaseModel):
     num_beams: int = 1
@@ -11,4 +11,18 @@ class GeneratorTransformersSettings(ExtraFieldsNotAllowedBaseModel):
     top_k: int = 50
     temperature: float = 1.0
     stop_strings: str | list[str] = '</s>'
+
+class VLLMSampleingSettings(ExtraFieldsNotAllowedBaseModel):
+    n: int = 1
+    repetition_penalty: float = 1.0
+    temperature: float = 1.0
+    top_p: float = 1.0
+    top_k: int = 50
+    max_tokens: int = 15
     logprobs: int | None = None
+
+class VLLMGeneratorSettings(ExtraFieldsNotAllowedBaseModel):
+    sampling_params: VLLMSampleingSettings = Field(default_factory=VLLMSampleingSettings)
+    best_of: int = 1
+    use_beam_search: bool = False
+    stop_strings: str | list[str] = '</s>'

--- a/turbo_alignment/settings/tf/generation.py
+++ b/turbo_alignment/settings/tf/generation.py
@@ -1,5 +1,7 @@
-from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 from pydantic import Field
+
+from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
+
 
 class GeneratorTransformersSettings(ExtraFieldsNotAllowedBaseModel):
     num_beams: int = 1
@@ -12,6 +14,7 @@ class GeneratorTransformersSettings(ExtraFieldsNotAllowedBaseModel):
     temperature: float = 1.0
     stop_strings: str | list[str] = '</s>'
 
+
 class VLLMSampleingSettings(ExtraFieldsNotAllowedBaseModel):
     n: int = 1
     repetition_penalty: float = 1.0
@@ -20,6 +23,7 @@ class VLLMSampleingSettings(ExtraFieldsNotAllowedBaseModel):
     top_k: int = 50
     max_tokens: int = 15
     logprobs: int | None = None
+
 
 class VLLMGeneratorSettings(ExtraFieldsNotAllowedBaseModel):
     sampling_params: VLLMSampleingSettings = Field(default_factory=VLLMSampleingSettings)

--- a/turbo_alignment/settings/tf/vllm.py
+++ b/turbo_alignment/settings/tf/vllm.py
@@ -4,7 +4,6 @@ from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 
 
 class EngineSettings(ExtraFieldsNotAllowedBaseModel):
-    model: str
     dtype: Optional[Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32']] = 'auto'
     tensor_parallel_size: int = 1
     gpu_memory_utilization: Optional[float] = 0.9

--- a/turbo_alignment/settings/tf/vllm.py
+++ b/turbo_alignment/settings/tf/vllm.py
@@ -1,0 +1,13 @@
+from typing import Optional, Literal
+
+from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
+
+
+class EngineSettings(ExtraFieldsNotAllowedBaseModel):
+    model: str
+    dtype: Optional[Literal["auto", "half", "float16", "bfloat16", "float", "float32"]] = "auto"
+    tensor_parallel_size: int = 1
+    gpu_memory_utilization: Optional[float] = 0.9
+    max_logprobs: Optional[int] = None
+    enable_lora: bool = False
+    max_lora_rank: Optional[int] = None

--- a/turbo_alignment/settings/tf/vllm.py
+++ b/turbo_alignment/settings/tf/vllm.py
@@ -1,11 +1,11 @@
-from typing import Optional, Literal
+from typing import Literal, Optional
 
 from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 
 
 class EngineSettings(ExtraFieldsNotAllowedBaseModel):
     model: str
-    dtype: Optional[Literal["auto", "half", "float16", "bfloat16", "float", "float32"]] = "auto"
+    dtype: Optional[Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32']] = 'auto'
     tensor_parallel_size: int = 1
     gpu_memory_utilization: Optional[float] = 0.9
     max_logprobs: Optional[int] = None

--- a/turbo_alignment/settings/tf/vllm.py
+++ b/turbo_alignment/settings/tf/vllm.py
@@ -4,7 +4,7 @@ from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 
 
 class EngineSettings(ExtraFieldsNotAllowedBaseModel):
-    dtype: Optional[Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32']] = 'bfloat16'
+    dtype: Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'] | None = 'bfloat16'
     tensor_parallel_size: int = 1
     gpu_memory_utilization: float | None = 0.95
     max_logprobs: int | None = None

--- a/turbo_alignment/settings/tf/vllm.py
+++ b/turbo_alignment/settings/tf/vllm.py
@@ -9,4 +9,4 @@ class EngineSettings(ExtraFieldsNotAllowedBaseModel):
     gpu_memory_utilization: float | None = 0.95
     max_logprobs: int | None = None
     enable_lora: bool = False
-    max_lora_rank: int | None = None
+    max_lora_rank: int | None = 16

--- a/turbo_alignment/settings/tf/vllm.py
+++ b/turbo_alignment/settings/tf/vllm.py
@@ -4,9 +4,9 @@ from turbo_alignment.settings.base import ExtraFieldsNotAllowedBaseModel
 
 
 class EngineSettings(ExtraFieldsNotAllowedBaseModel):
-    dtype: Optional[Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32']] = 'auto'
+    dtype: Optional[Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32']] = 'bfloat16'
     tensor_parallel_size: int = 1
-    gpu_memory_utilization: Optional[float] = 0.9
+    gpu_memory_utilization: Optional[float] = 0.95
     max_logprobs: Optional[int] = None
     enable_lora: bool = False
     max_lora_rank: Optional[int] = None


### PR DESCRIPTION
### Changes Made

- **vLLM Engine Parameters:** Separated into their own block ⚙️  
- **vLLM Parameters:** Added `max_lora_rank`, `max_logprobs` , `filter_token_ids`.
- **Logprobs:** For generation with vLLM, the `logprobs` parameters are now correctly passed through  
- **Test Configuration:** Adjustments have been made to the test config  
- **Token Filtering:** Added filtering for specific tokens. Note: With a high number of logprobs (vocab_size), generating one token can take seconds. ⏱️

---

### Test Results

| № | Test Scenario                                                 | Outcome                                                                                                                                                          |
|-----|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 1   | `max_logprobs` < `logprobs`                                     | **Error:** "ValueError: Cannot request more than 1 logprobs." ❌                                                                                                   |
| 2   | `max_lora_rank` < `lora_rank`                                   | **Error:** "ValueError: LoRA rank 16 is greater than max_lora_rank 8." ❌                                                                                           |
| 3   | `use_vllm: false`                                               | Worked correctly. ✅                                                                                                                                              |
| 4   | Running without `vllm_settings`                                 | Works correctly. ✅                                                                                                                                              |
| 5   | Running without `filter_token_ids`                              | Works correctly. ✅                                                                                                                                              |
| 6   | Running with `filter_token_ids` [9693, 2152]                    | Works correctly. In `logprobs`, only 2 tokens are present. Generation speed decreased by half (from 50 tokens to 25 tokens per second) – function affects latency. ⚠️ |
| 7   | `max_logprobs` ≥ `logprobs`                                     | Works correctly. ✅                                                                                                                                              |
| 8   | `max_lora_rank` ≥ `lora_rank`                                   | Works correctly. ✅                                                                                                                                              |
| 9   | Running without `logprobs`, but with `filter_token_ids`         | Works correctly. ✅                                                                                                                                              |
| 10   | Internal tests run via poetry                                   | Passed. ✅                                                                                                                                                      |
