### PR TITLE
Dtype and deepspeed

### DIFF
--- a/tests/cli/test_dpo_train.py
+++ b/tests/cli/test_dpo_train.py
@@ -22,5 +22,5 @@ def test_dpo_train(config_path: Path):
         app,
         ['train_dpo', '--experiment_settings_path', str(config_path)],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.exception
     assert DPOTrainExperimentSettings.parse_file(config_path).log_path.is_dir()

--- a/turbo_alignment/common/tf/loaders/model/model.py
+++ b/turbo_alignment/common/tf/loaders/model/model.py
@@ -82,7 +82,6 @@ def load_model(
         model_settings.model_path,
         **model_settings.transformers_settings.dict(exclude_none=True),
         **model_settings.model_kwargs,
-        torch_dtype=torch.bfloat16,
     )
 
     if model_settings.transformers_settings.load_in_8bit:

--- a/turbo_alignment/settings/tf/model.py
+++ b/turbo_alignment/settings/tf/model.py
@@ -7,3 +7,5 @@ class ModelTransformersSettings(ExtraFieldsNotAllowedBaseModel):
     omit_base_model_save: bool | None = None
 
     trust_remote_code: bool = False
+
+    torch_dtype: str = 'bfloat16'

--- a/turbo_alignment/settings/tf/trainer.py
+++ b/turbo_alignment/settings/tf/trainer.py
@@ -30,7 +30,7 @@ class TrainerSettings(ExtraFieldsNotAllowedBaseModel):
     adam_epsilon: float = 1e-8
     weight_decay: float = 0.0
     max_grad_norm: float = 1.0
-    deepspeed: Path | None = None
+    deepspeed: Path | dict[str, Any] | None = None
     save_total_limit: int = 1
     save_only_model: bool = False
     no_cuda: bool = False


### PR DESCRIPTION
1) Dtype for model loading can be set in the settings file
2) Print exception if test fails
3) Deepspeed config can be inserted directly in the trainer settings file