### PR TITLE
Random generators

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,6 @@ def dpo_dataset(pair_preferences_dataset_source, tokenizer_llama2, chat_dataset_
     dataset_cls = DatasetRegistry.by_name(DatasetType.PAIR_PREFERENCES).by_name(DatasetStrategy.TRAIN)
 
     dataset_settings = PairPreferenceDatasetSettings(chat_settings=chat_dataset_settings)
-    dataset = dataset_cls(tokenizer=tokenizer_llama2, source=source, settings=dataset_settings)
+    dataset = dataset_cls(tokenizer=tokenizer_llama2, source=source, settings=dataset_settings, seed=42)
 
     return dataset

--- a/tests/unit/test_collators.py
+++ b/tests/unit/test_collators.py
@@ -12,7 +12,7 @@ def test_kto_collator(tokenizer_llama2, chat_dataset_settings, kto_dataset_sourc
     dataset_cls = DatasetRegistry.by_name(DatasetType.KTO).by_name(DatasetStrategy.TRAIN)
 
     dataset_settings = KTODatasetSettings(chat_settings=chat_dataset_settings)
-    dataset = dataset_cls(tokenizer=tokenizer, source=source, settings=dataset_settings)
+    dataset = dataset_cls(tokenizer=tokenizer, source=source, settings=dataset_settings, seed=42)
 
     batch_size = min(len(dataset), 8)
     examples = list(dataset)[:batch_size]

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -21,7 +21,7 @@ def test_classification(tokenizer_llama2, chat_dataset_settings, classification_
 
     dataset_settings = ClassificationDatasetSettings(chat_settings=chat_dataset_settings)
 
-    dataset = dataset_cls(tokenizer=tokenizer_llama2, source=source, settings=dataset_settings)
+    dataset = dataset_cls(tokenizer=tokenizer_llama2, source=source, settings=dataset_settings, seed=42)
 
     assert len(data_dicts) == len(dataset)
 
@@ -43,7 +43,7 @@ def test_pair_preferences(tokenizer_llama2, chat_dataset_settings, pair_preferen
     dataset_cls = DatasetRegistry.by_name(DatasetType.PAIR_PREFERENCES).by_name(DatasetStrategy.TRAIN)
 
     dataset_settings = PairPreferenceDatasetSettings(chat_settings=chat_dataset_settings)
-    dataset = dataset_cls(tokenizer=tokenizer_llama2, source=source, settings=dataset_settings)
+    dataset = dataset_cls(tokenizer=tokenizer_llama2, source=source, settings=dataset_settings, seed=42)
 
     assert len(data_dicts) == len(dataset)
 
@@ -71,7 +71,7 @@ def test_ddpo(tokenizer_llama2, tokenizer_gptj, chat_dataset_settings, pair_pref
         chat_settings=chat_dataset_settings, pair_preferences=pair_preferences_dataset_settings
     )
     dataset = dataset_cls(
-        chat_tokenizer=sft_tokenizer, rm_tokenizer=rm_tokenizer, source=source, settings=dataset_settings
+        chat_tokenizer=sft_tokenizer, rm_tokenizer=rm_tokenizer, source=source, settings=dataset_settings, seed=42
     )
 
     assert len(data_dicts) == len(dataset)

--- a/turbo_alignment/dataset/base/base.py
+++ b/turbo_alignment/dataset/base/base.py
@@ -28,6 +28,7 @@ class BaseDataset(Dataset, ABC, Generic[RecordT]):
     ) -> None:
         self.source = source
         self.settings = settings
+        self.sampler = random.Random(self.settings.sample_random_seed)
 
         self.original_records_map: dict[str, RecordT] = {}
         self.records: list[dict[str, torch.Tensor]] = []
@@ -54,7 +55,7 @@ class BaseDataset(Dataset, ABC, Generic[RecordT]):
         if self.source.sample_rate is not None:
             logger.info(f'Sampling dataset {self.source.name} with sample rate: {self.source.sample_rate}')
             sampled_original_records = {
-                record.id: record for record in original_records if random.random() <= self.source.sample_rate
+                record.id: record for record in original_records if self.sampler.random() <= self.source.sample_rate
             }
         elif self.source.num_samples is not None:
             logger.info(f'Sampling {self.source.num_samples} from dataset {self.source.name}')

--- a/turbo_alignment/dataset/base/base.py
+++ b/turbo_alignment/dataset/base/base.py
@@ -25,10 +25,12 @@ class BaseDataset(Dataset, ABC, Generic[RecordT]):
         self,
         source: DatasetSourceSettings,
         settings: BaseDatasetSettings,
+        seed: int,
     ) -> None:
         self.source = source
         self.settings = settings
-        self.sampler = random.Random(self.settings.sample_random_seed)
+        self.seed = seed
+        self.sampler = random.Random(seed)
 
         self.original_records_map: dict[str, RecordT] = {}
         self.records: list[dict[str, torch.Tensor]] = []
@@ -110,8 +112,9 @@ class AlignmentDataset(BaseDataset, ABC, Generic[RecordT]):
         source: DatasetSourceSettings,
         settings: BaseDatasetSettings,
         tokenizer: PreTrainedTokenizerBase,
+        seed: int,
     ) -> None:
-        super().__init__(source=source, settings=settings)
+        super().__init__(source=source, settings=settings, seed=seed)
 
         self.tokenizer = tokenizer
         self._logged = False

--- a/turbo_alignment/dataset/chat/chat.py
+++ b/turbo_alignment/dataset/chat/chat.py
@@ -37,11 +37,12 @@ class ChatDataset(AlignmentDataset[ChatDatasetRecord], ABC):
         source: DatasetSourceSettings,
         settings: ChatDatasetSettings,
         tokenizer: PreTrainedTokenizerBase,
+        seed: int,
         read: bool = True,
     ) -> None:
-        super().__init__(source=source, settings=settings, tokenizer=tokenizer)
+        super().__init__(source=source, settings=settings, tokenizer=tokenizer, seed=seed)
         self.settings: ChatDatasetSettings = settings
-        self.random_cut_generator = random.Random(self.settings.random_cut_seed)
+        self.cut_generator = random.Random(self.seed)
 
         if read:
             self._read()
@@ -193,7 +194,7 @@ class ChatDataset(AlignmentDataset[ChatDatasetRecord], ABC):
                 for i, m in enumerate(conversation.messages)
                 if m.role == ChatMessageRole.BOT and left_bound <= i < right_bound
             ]
-            right_bound = self.random_cut_generator.choice(bot_indices) if bot_indices else right_bound
+            right_bound = self.cut_generator.choice(bot_indices) if bot_indices else right_bound
 
         input_ids = np.array([])
         labels = np.array([])
@@ -355,12 +356,13 @@ class InferenceChatDataset(ChatDataset):
         source: DatasetSourceSettings,
         settings: ChatDatasetSettings,
         tokenizer: PreTrainedTokenizerBase,
+        seed: int,
         read: bool = True,
         random_cut: bool = False,
     ) -> None:
         self._random_cut = random_cut
 
-        super().__init__(source=source, settings=settings, tokenizer=tokenizer, read=read)
+        super().__init__(source=source, settings=settings, tokenizer=tokenizer, read=read, seed=seed)
 
     def convert_records(self, records: list[ChatDatasetRecord]) -> list[dict[str, Any] | None]:
         return self._encode(records, inference=True, random_cut=self._random_cut)
@@ -371,7 +373,7 @@ class InferenceChatDataset(ChatDataset):
             settings=self.settings,
             tokenizer=self.tokenizer,
             read=False,
-            random_cut=self._random_cut,
+            seed=self.seed,
         )
 
         dataset_records = [self[idx] for idx in range(len(self))]

--- a/turbo_alignment/dataset/chat/chat.py
+++ b/turbo_alignment/dataset/chat/chat.py
@@ -41,6 +41,7 @@ class ChatDataset(AlignmentDataset[ChatDatasetRecord], ABC):
     ) -> None:
         super().__init__(source=source, settings=settings, tokenizer=tokenizer)
         self.settings: ChatDatasetSettings = settings
+        self.random_cut_generator = random.Random(self.settings.random_cut_seed)
 
         if read:
             self._read()
@@ -192,7 +193,7 @@ class ChatDataset(AlignmentDataset[ChatDatasetRecord], ABC):
                 for i, m in enumerate(conversation.messages)
                 if m.role == ChatMessageRole.BOT and left_bound <= i < right_bound
             ]
-            right_bound = random.choice(bot_indices) if bot_indices else right_bound
+            right_bound = self.random_cut_generator.choice(bot_indices) if bot_indices else right_bound
 
         input_ids = np.array([])
         labels = np.array([])

--- a/turbo_alignment/dataset/classification/classification.py
+++ b/turbo_alignment/dataset/classification/classification.py
@@ -29,15 +29,17 @@ class ClassificationDataset(AlignmentDataset[ClassificationDatasetRecord], ABC):
         source: DatasetSourceSettings,
         settings: ClassificationDatasetSettings,
         tokenizer: PreTrainedTokenizerBase,
+        seed: int,
     ):
         settings.chat_settings.only_answer_loss = False
         self._chat_dataset = TrainChatDataset(
             source=source,
             settings=settings.chat_settings,
             tokenizer=tokenizer,
+            seed=seed,
             read=False,
         )
-        super().__init__(source=source, settings=settings, tokenizer=tokenizer)
+        super().__init__(source=source, settings=settings, tokenizer=tokenizer, seed=seed)
         self.settings: ClassificationDatasetSettings = settings
 
         self._read()
@@ -99,6 +101,7 @@ class InferenceClassificationDataset(ClassificationDataset):
             source=self.source,
             settings=self.settings,
             tokenizer=self.tokenizer,
+            seed=self.seed,
         )
 
         dataset_records = [self[idx] for idx in range(len(self))]

--- a/turbo_alignment/dataset/ddpo/ddpo.py
+++ b/turbo_alignment/dataset/ddpo/ddpo.py
@@ -33,6 +33,7 @@ class DDPODataset(BaseDataset[PairPreferenceRecord]):
         settings: DDPOMultiDatasetSettings,
         chat_tokenizer: PreTrainedTokenizerBase,
         rm_tokenizer: PreTrainedTokenizerBase,
+        seed: int,
         read: bool = True,
     ) -> None:
         settings.chat_settings.keep_end = True
@@ -40,17 +41,20 @@ class DDPODataset(BaseDataset[PairPreferenceRecord]):
             settings=settings.chat_settings,
             source=source,
             tokenizer=chat_tokenizer,
+            seed=seed,
             read=False,
         )
         self._rm_dataset = PairPreferenceDataset(
             settings=settings.pair_preferences,
             source=source,
             tokenizer=rm_tokenizer,
+            seed=seed,
         )
 
         super().__init__(
             settings=settings,
             source=source,
+            seed=seed,
         )
         if read:
             self._read()
@@ -121,6 +125,7 @@ def load_ddpo_datasets(
     multi_dataset_settings: DDPOMultiDatasetSettings,
     chat_tokenizer: PreTrainedTokenizerBase,
     rm_tokenizer: PreTrainedTokenizerBase,
+    seed: int,
 ) -> list[DDPODataset]:
     logger.info(
         f'Loading dataset {multi_dataset_settings.dataset_type} with settings:\n{multi_dataset_settings.dict()}'
@@ -135,6 +140,7 @@ def load_ddpo_datasets(
             rm_tokenizer=rm_tokenizer,
             source=source,
             settings=multi_dataset_settings,
+            seed=seed,
         )
 
         datasets.append(dataset)

--- a/turbo_alignment/dataset/kto/kto.py
+++ b/turbo_alignment/dataset/kto/kto.py
@@ -27,15 +27,17 @@ class KTODataset(AlignmentDataset[KTODatasetRecord]):
         source: DatasetSourceSettings,
         settings: KTODatasetSettings,
         tokenizer: PreTrainedTokenizerBase,
+        seed: int,
     ):
         self._chat_dataset = TrainChatDataset(
             source=source,
             settings=settings.chat_settings,
             tokenizer=tokenizer,
+            seed=seed,
             read=False,
         )
-        super().__init__(source=source, settings=settings, tokenizer=tokenizer)
-        self.shuffle_generator = random.Random(settings.shuffle_seed)
+        super().__init__(source=source, settings=settings, tokenizer=tokenizer, seed=seed)
+        self.shuffle_generator = random.Random(self.seed)
 
         self._read()
 

--- a/turbo_alignment/dataset/kto/kto.py
+++ b/turbo_alignment/dataset/kto/kto.py
@@ -35,12 +35,13 @@ class KTODataset(AlignmentDataset[KTODatasetRecord]):
             read=False,
         )
         super().__init__(source=source, settings=settings, tokenizer=tokenizer)
+        self.shuffle_generator = random.Random(settings.shuffle_seed)
 
         self._read()
 
     def convert_records(self, records: list[KTODatasetRecord]) -> list[dict[str, Any] | None]:
         shuffled_records = deepcopy(records)
-        random.shuffle(shuffled_records)
+        self.shuffle_generator.shuffle(shuffled_records)
 
         kl_records = []
         chat_records = []

--- a/turbo_alignment/dataset/loader.py
+++ b/turbo_alignment/dataset/loader.py
@@ -22,6 +22,7 @@ class DatasetLoader(Generic[DatasetType]):
         multi_dataset_settings: MultiDatasetSettings,
         tokenizer: PreTrainedTokenizerBase,
         strategy: DatasetStrategy,
+        seed: int,
     ) -> list[DatasetType]:
         logger.info(
             f'Loading dataset {multi_dataset_settings.dataset_type} with settings:\n{multi_dataset_settings.dict()}'
@@ -35,6 +36,7 @@ class DatasetLoader(Generic[DatasetType]):
                 tokenizer=tokenizer,
                 source=source,
                 settings=multi_dataset_settings,
+                seed=seed,
             )
 
             if self._dataset_cls is not None:

--- a/turbo_alignment/dataset/multimodal/multimodal.py
+++ b/turbo_alignment/dataset/multimodal/multimodal.py
@@ -30,8 +30,8 @@ logger = get_project_logger()
 
 
 class MultimodalDataset(AlignmentDataset[MultimodalDatasetRecord], ABC):
-    def __init__(self, tokenizer, source, settings):
-        super().__init__(tokenizer=tokenizer, source=source, settings=settings)
+    def __init__(self, tokenizer, source, settings, seed: int):
+        super().__init__(tokenizer=tokenizer, source=source, settings=settings, seed=seed)
 
         self._n_modality_embeddings = settings.n_modality_embeddings
         self._modality_reader_settings_mapping = settings.modality_reader_settings_mapping
@@ -140,7 +140,7 @@ class MultimodalDataset(AlignmentDataset[MultimodalDatasetRecord], ABC):
 
 @MultimodalDatasetTypeRegistry.register(DatasetStrategy.TRAIN)
 class TrainMultimodalDataset(MultimodalDataset):
-    def __init__(self, tokenizer, source, settings) -> None:
+    def __init__(self, tokenizer, source, settings, seed: int) -> None:
         """
 
         :param n_modality_embeddings: сколько токенов выделяем под одно сообщение с нетекстовой модальностью
@@ -150,9 +150,11 @@ class TrainMultimodalDataset(MultimodalDataset):
         :param truncate_top: обрезаем диалог сверху или снизу, если он не влазит в max_tokens
         """
 
-        super().__init__(tokenizer=tokenizer, source=source, settings=settings)
+        super().__init__(tokenizer=tokenizer, source=source, settings=settings, seed=seed)
 
-        self._chat_dataset = TrainChatDataset(tokenizer=tokenizer, source=source, settings=settings, read=False)
+        self._chat_dataset = TrainChatDataset(
+            tokenizer=tokenizer, source=source, settings=settings, seed=seed, read=False
+        )
 
         self._read()
 
@@ -207,6 +209,7 @@ class InferenceMultimodalDataset(MultimodalDataset):
     def __init__(
         self,
         *args,
+        seed: int,
         random_cut: bool = False,
         **kwargs,
     ) -> None:
@@ -214,7 +217,7 @@ class InferenceMultimodalDataset(MultimodalDataset):
         settings = kwargs['settings']
         settings.random_cut = random_cut
         self._chat_dataset = InferenceChatDataset(
-            tokenizer=kwargs['tokenizer'], source=kwargs['source'], settings=settings, read=False
+            tokenizer=kwargs['tokenizer'], source=kwargs['source'], settings=settings, read=False, seed=seed
         )
         self._read()
 

--- a/turbo_alignment/dataset/pair_preferences/pair_preference.py
+++ b/turbo_alignment/dataset/pair_preferences/pair_preference.py
@@ -32,6 +32,7 @@ class PairPreferenceDataset(AlignmentDataset[PairPreferenceRecord]):
         source: DatasetSourceSettings,
         settings: PairPreferenceDatasetSettings,
         tokenizer: PreTrainedTokenizerBase,
+        seed: int,
         read: bool = True,
     ):
         self._add_labels = settings.add_labels
@@ -40,9 +41,10 @@ class PairPreferenceDataset(AlignmentDataset[PairPreferenceRecord]):
             source=source,
             settings=settings.chat_settings,
             tokenizer=tokenizer,
+            seed=seed,
             read=False,
         )
-        super().__init__(source=source, settings=settings, tokenizer=tokenizer)
+        super().__init__(source=source, settings=settings, tokenizer=tokenizer, seed=seed)
         self.settings: PairPreferenceDatasetSettings = settings
 
         if read:
@@ -115,6 +117,7 @@ class PairPreferenceDataset(AlignmentDataset[PairPreferenceRecord]):
             source=self.source,
             settings=self.settings,
             tokenizer=self.tokenizer,
+            seed=self.seed,
             read=False,
         )
 

--- a/turbo_alignment/dataset/sampling/rm.py
+++ b/turbo_alignment/dataset/sampling/rm.py
@@ -26,6 +26,7 @@ class SamplingRMDataset(AlignmentDataset[SamplingDatasetRecord]):
         source: DatasetSourceSettings,
         settings: ChatDatasetSettings,
         tokenizer: PreTrainedTokenizerBase,
+        seed: int,
         read: bool = True,
     ) -> None:
         settings.keep_end = True
@@ -33,9 +34,10 @@ class SamplingRMDataset(AlignmentDataset[SamplingDatasetRecord]):
             settings=settings,
             source=source,
             tokenizer=tokenizer,
+            seed=seed,
             read=False,
         )
-        super().__init__(source=source, settings=settings, tokenizer=tokenizer)
+        super().__init__(source=source, settings=settings, tokenizer=tokenizer, seed=seed)
         self.settings: ChatDatasetSettings = settings
 
         if read:

--- a/turbo_alignment/metrics/reward.py
+++ b/turbo_alignment/metrics/reward.py
@@ -64,6 +64,7 @@ class RewardMetric(Metric):
             source=DatasetSourceSettings(name='', records_data=rm_input_records, sample_rate=1.0),
             settings=chat_settings,
             tokenizer=self.tokenizer,
+            seed=42,  # we set sample_ratio to 1.0, so no sampling
         )
 
         generator_outputs = generator.generate_from_dataset(new_dataset)

--- a/turbo_alignment/pipelines/inference/base.py
+++ b/turbo_alignment/pipelines/inference/base.py
@@ -45,6 +45,7 @@ class BaseInferenceStrategy(BaseStrategy, Generic[InferenceExperimentSettingsT])
                 experiment_settings.dataset_settings,
                 tokenizer=tokenizer,
                 strategy=DatasetStrategy.INFERENCE,
+                seed=experiment_settings.seed,
             )
             generations_output: list[BaseModel] = sum(
                 [gather_object(generator.generate_from_dataset(dataset)) for dataset in datasets], []

--- a/turbo_alignment/pipelines/sampling/rm.py
+++ b/turbo_alignment/pipelines/sampling/rm.py
@@ -70,6 +70,7 @@ class BaseSamplingStrategyWithRM(BaseSamplingStrategy[SamplingSettingsWithRMT], 
             source=experiment_settings.dataset_settings.sources[0],
             settings=experiment_settings.dataset_settings.chat_dataset,
             tokenizer=tokenizer,
+            seed=experiment_settings.seed,
         )
 
         rewards = self._get_rewards(

--- a/turbo_alignment/pipelines/train/base.py
+++ b/turbo_alignment/pipelines/train/base.py
@@ -159,6 +159,7 @@ class BaseTrainStrategy(S3Mixin, BaseStrategy, Generic[ExperimentSettingsT]):
                 experiment_settings.train_dataset_settings,
                 tokenizer=self.tokenizer,
                 strategy=DatasetStrategy.TRAIN,
+                seed=experiment_settings.seed,
             )
         )
 
@@ -167,6 +168,7 @@ class BaseTrainStrategy(S3Mixin, BaseStrategy, Generic[ExperimentSettingsT]):
                 experiment_settings.val_dataset_settings,
                 tokenizer=self.tokenizer,
                 strategy=DatasetStrategy.TRAIN,
+                seed=experiment_settings.seed,
             )
         )
 

--- a/turbo_alignment/pipelines/train/classification.py
+++ b/turbo_alignment/pipelines/train/classification.py
@@ -53,7 +53,12 @@ class TrainClassificationStrategy(BaseTrainStrategy[ClassificationTrainExperimen
 
         cherry_pick_datasets = DatasetLoader[InferenceClassificationDataset](
             InferenceClassificationDataset
-        ).load_datasets(cherry_pick_settings.dataset_settings, tokenizer=tokenizer, strategy=DatasetStrategy.INFERENCE)
+        ).load_datasets(
+            cherry_pick_settings.dataset_settings,
+            tokenizer=tokenizer,
+            strategy=DatasetStrategy.INFERENCE,
+            seed=experiment_settings.seed,
+        )
 
         metrics = [
             Metric.by_name(metric.type)(MetricSettingsRegistry.by_name(metric.type)(**metric.parameters))

--- a/turbo_alignment/pipelines/train/ddpo.py
+++ b/turbo_alignment/pipelines/train/ddpo.py
@@ -46,7 +46,10 @@ class TrainDDPOStrategy(BaseTrainStrategy[DDPOTrainExperimentSettings]):
             return None
 
         cherry_pick_datasets = DatasetLoader[InferenceChatDataset](InferenceChatDataset).load_datasets(
-            cherry_pick_settings.dataset_settings, tokenizer=tokenizer, strategy=DatasetStrategy.INFERENCE
+            cherry_pick_settings.dataset_settings,
+            tokenizer=tokenizer,
+            strategy=DatasetStrategy.INFERENCE,
+            seed=experiment_settings.seed,
         )
 
         metrics = [
@@ -157,6 +160,7 @@ class TrainDDPOStrategy(BaseTrainStrategy[DDPOTrainExperimentSettings]):
                 experiment_settings.train_dataset_settings,
                 rm_tokenizer=self.rm_tokenizer,
                 chat_tokenizer=self.tokenizer,
+                seed=experiment_settings.seed,
             )
         )
         val_dataset: ConcatDataset = ConcatDataset(
@@ -164,6 +168,7 @@ class TrainDDPOStrategy(BaseTrainStrategy[DDPOTrainExperimentSettings]):
                 experiment_settings.val_dataset_settings,
                 rm_tokenizer=self.rm_tokenizer,
                 chat_tokenizer=self.tokenizer,
+                seed=experiment_settings.seed,
             )
         )
 

--- a/turbo_alignment/pipelines/train/dpo.py
+++ b/turbo_alignment/pipelines/train/dpo.py
@@ -41,7 +41,10 @@ class TrainDPOStrategy(BaseTrainStrategy[DPOTrainExperimentSettings]):
             return None
 
         cherry_pick_datasets = DatasetLoader[InferenceChatDataset](InferenceChatDataset).load_datasets(
-            cherry_pick_settings.dataset_settings, tokenizer=tokenizer, strategy=DatasetStrategy.INFERENCE
+            cherry_pick_settings.dataset_settings,
+            tokenizer=tokenizer,
+            strategy=DatasetStrategy.INFERENCE,
+            seed=experiment_settings.seed,
         )
 
         metrics = [

--- a/turbo_alignment/pipelines/train/kto.py
+++ b/turbo_alignment/pipelines/train/kto.py
@@ -41,7 +41,10 @@ class TrainKTOStrategy(BaseTrainStrategy[KTOTrainExperimentSettings]):
             return None
 
         cherry_pick_datasets = DatasetLoader[InferenceChatDataset](InferenceChatDataset).load_datasets(
-            cherry_pick_settings.dataset_settings, tokenizer=tokenizer, strategy=DatasetStrategy.INFERENCE
+            cherry_pick_settings.dataset_settings,
+            tokenizer=tokenizer,
+            strategy=DatasetStrategy.INFERENCE,
+            seed=experiment_settings.seed,
         )
 
         metrics = [

--- a/turbo_alignment/pipelines/train/multimodal.py
+++ b/turbo_alignment/pipelines/train/multimodal.py
@@ -48,7 +48,10 @@ class TrainMultimodalStrategy(MultimodalMixin, BaseTrainStrategy[MultimodalTrain
             return None
 
         cherry_pick_datasets = DatasetLoader[InferenceMultimodalDataset](InferenceMultimodalDataset).load_datasets(
-            cherry_pick_settings.dataset_settings, tokenizer=tokenizer, strategy=DatasetStrategy.INFERENCE
+            cherry_pick_settings.dataset_settings,
+            tokenizer=tokenizer,
+            strategy=DatasetStrategy.INFERENCE,
+            seed=experiment_settings.seed,
         )
 
         metrics = [

--- a/turbo_alignment/pipelines/train/rag.py
+++ b/turbo_alignment/pipelines/train/rag.py
@@ -51,7 +51,10 @@ class TrainRAGStrategy(BaseTrainStrategy[RAGTrainExperimentSettings]):
             return None
 
         cherry_pick_datasets = DatasetLoader[InferenceChatDataset](InferenceChatDataset).load_datasets(
-            cherry_pick_settings.dataset_settings, tokenizer=tokenizer, strategy=DatasetStrategy.INFERENCE
+            cherry_pick_settings.dataset_settings,
+            tokenizer=tokenizer,
+            strategy=DatasetStrategy.INFERENCE,
+            seed=experiment_settings.seed,
         )
 
         metrics = [

--- a/turbo_alignment/pipelines/train/rm.py
+++ b/turbo_alignment/pipelines/train/rm.py
@@ -43,7 +43,10 @@ class TrainRMStrategy(BaseTrainStrategy[RMTrainExperimentSettings]):
             return None
 
         cherry_pick_datasets = DatasetLoader[PairPreferenceDataset](PairPreferenceDataset).load_datasets(
-            cherry_pick_settings.dataset_settings, tokenizer=tokenizer, strategy=DatasetStrategy.TRAIN
+            cherry_pick_settings.dataset_settings,
+            tokenizer=tokenizer,
+            strategy=DatasetStrategy.TRAIN,
+            seed=experiment_settings.seed,
         )
 
         metrics = [

--- a/turbo_alignment/pipelines/train/sft.py
+++ b/turbo_alignment/pipelines/train/sft.py
@@ -42,7 +42,10 @@ class TrainSFTStrategy(BaseTrainStrategy[SftTrainExperimentSettings]):
             return None
 
         cherry_pick_datasets = DatasetLoader[InferenceChatDataset](InferenceChatDataset).load_datasets(
-            cherry_pick_settings.dataset_settings, tokenizer=tokenizer, strategy=DatasetStrategy.INFERENCE
+            cherry_pick_settings.dataset_settings,
+            tokenizer=tokenizer,
+            strategy=DatasetStrategy.INFERENCE,
+            seed=experiment_settings.seed,
         )
 
         metrics = [

--- a/turbo_alignment/settings/datasets/base.py
+++ b/turbo_alignment/settings/datasets/base.py
@@ -23,6 +23,7 @@ class DatasetStrategy(str, Enum):
 
 class BaseDatasetSettings(ExtraFieldsNotAllowedBaseModel):
     dataset_type: DatasetType
+    sample_random_seed: int = 42
 
 
 class DatasetSourceSettings(ExtraFieldsNotAllowedBaseModel):

--- a/turbo_alignment/settings/datasets/base.py
+++ b/turbo_alignment/settings/datasets/base.py
@@ -23,7 +23,6 @@ class DatasetStrategy(str, Enum):
 
 class BaseDatasetSettings(ExtraFieldsNotAllowedBaseModel):
     dataset_type: DatasetType
-    sample_random_seed: int = 42
 
 
 class DatasetSourceSettings(ExtraFieldsNotAllowedBaseModel):

--- a/turbo_alignment/settings/datasets/chat.py
+++ b/turbo_alignment/settings/datasets/chat.py
@@ -21,6 +21,7 @@ class ChatDatasetSettings(BaseDatasetSettings):
     only_last_replica_loss: bool = False
     only_answer_loss: bool = True
     random_cut: bool = False  # TODO: not common property for train/inference
+    random_cut_seed: int = 42
 
     keep_end: bool | None = None
     max_tokens_count: int | None

--- a/turbo_alignment/settings/datasets/kto.py
+++ b/turbo_alignment/settings/datasets/kto.py
@@ -11,7 +11,6 @@ from turbo_alignment.settings.datasets.chat import ChatDatasetSettings
 class KTODatasetSettings(BaseDatasetSettings):
     dataset_type: Literal[DatasetType.KTO] = DatasetType.KTO
     chat_settings: ChatDatasetSettings
-    shuffle_seed: int = 54
 
 
 class KTOMultiDatasetSettings(KTODatasetSettings, MultiDatasetSettings):

--- a/turbo_alignment/settings/datasets/kto.py
+++ b/turbo_alignment/settings/datasets/kto.py
@@ -11,6 +11,7 @@ from turbo_alignment.settings.datasets.chat import ChatDatasetSettings
 class KTODatasetSettings(BaseDatasetSettings):
     dataset_type: Literal[DatasetType.KTO] = DatasetType.KTO
     chat_settings: ChatDatasetSettings
+    shuffle_seed: int = 54
 
 
 class KTOMultiDatasetSettings(KTODatasetSettings, MultiDatasetSettings):

--- a/turbo_alignment/settings/pipelines/inference/base.py
+++ b/turbo_alignment/settings/pipelines/inference/base.py
@@ -34,3 +34,4 @@ class InferenceExperimentSettings(ExtraFieldsNotAllowedBaseModel):
 
     dataset_settings: INFERENCE_DATASETS_SETTINGS
     save_path: Path
+    seed: int = 42

--- a/turbo_alignment/settings/pipelines/inference/rag.py
+++ b/turbo_alignment/settings/pipelines/inference/rag.py
@@ -21,3 +21,4 @@ class RAGInferenceExperimentSettings(ExtraFieldsNotAllowedBaseModel):
 
     dataset_settings: ChatMultiDatasetSettings
     save_path: Path
+    seed: int = 42

--- a/turbo_alignment/settings/pipelines/sampling/sampling.py
+++ b/turbo_alignment/settings/pipelines/sampling/sampling.py
@@ -25,6 +25,7 @@ class BaseSamplingWithRMSettings(BaseSamplingSettings):
     tokenizer_settings: TokenizerSettings
 
     rm_batch_size: int
+    seed: int = 42
 
 
 class SamplingWithRMSettings(BaseSamplingWithRMSettings):


### PR DESCRIPTION
We use separate generators for each task. There are several reasons to do it:
1) It improves reproducibility
2) When we are doing sequence parallel training, we must be sure that all generators of all workers inside one sequence parallel group are perfectly synchornized